### PR TITLE
Update Dockerfile

### DIFF
--- a/exercise1/providers.tf
+++ b/exercise1/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "2.5.1"
     }
   }
-  required_version = "1.9.4"
+  required_version = "1.9.7"
 }

--- a/exercise1/providers.tf
+++ b/exercise1/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = "2.5.1"
+      version = "2.5.2"
     }
   }
   required_version = "1.9.7"

--- a/exercise2/Dockerfile
+++ b/exercise2/Dockerfile
@@ -1,4 +1,4 @@
-FROM dahicks/sample:latest as build
+FROM dahicks/sample:latest AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN useradd --no-log-init -m -r -g root bonkey
 COPY helloworld.py /app/main.py

--- a/exercise2/Dockerfile
+++ b/exercise2/Dockerfile
@@ -12,3 +12,4 @@ RUN cd /app && \
 
 ENTRYPOINT ["python3", "/app/main.py"]
 USER bonkey
+

--- a/exercise2/Dockerfile
+++ b/exercise2/Dockerfile
@@ -12,4 +12,3 @@ RUN cd /app && \
 
 ENTRYPOINT ["python3", "/app/main.py"]
 USER bonkey
-

--- a/exercise6/modules/helloworld/providers.tf
+++ b/exercise6/modules/helloworld/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "2.5.1"
     }
   }
-  required_version = "1.9.4"
+  required_version = "1.9.7"
 }

--- a/exercise6/modules/helloworld/providers.tf
+++ b/exercise6/modules/helloworld/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = "2.5.1"
+      version = "2.5.2"
     }
   }
   required_version = "1.9.7"

--- a/exercise6/providers.tf
+++ b/exercise6/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "2.5.1"
     }
   }
-  required_version = "1.9.4"
+  required_version = "1.9.7"
 }

--- a/exercise6/providers.tf
+++ b/exercise6/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = "2.5.1"
+      version = "2.5.2"
     }
   }
   required_version = "1.9.7"

--- a/modules/module1/providers.tf
+++ b/modules/module1/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "2.5.1"
     }
   }
-  required_version = "1.9.4"
+  required_version = "1.9.7"
 }

--- a/modules/module1/providers.tf
+++ b/modules/module1/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = "2.5.1"
+      version = "2.5.2"
     }
   }
   required_version = "1.9.7"

--- a/modules/module2/providers.tf
+++ b/modules/module2/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "2.5.1"
     }
   }
-  required_version = "1.9.4"
+  required_version = "1.9.7"
 }

--- a/modules/module2/providers.tf
+++ b/modules/module2/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = "2.5.1"
+      version = "2.5.2"
     }
   }
   required_version = "1.9.7"


### PR DESCRIPTION
fix warning during docker build

# SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Currently, a person doing the exercises will see a warning during the docker build step. Capitalizing `AS` to match `FROM` fixes that.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

## PR TYPE

<!--- Pick one below and delete the rest: -->
- EXERCISE

## ADDITIONAL INFORMATION

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Just do the steps in exercise2, you'll see the warning during the image build step.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```code
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```
